### PR TITLE
Handle downloads no data available

### DIFF
--- a/src/ecmwf_models/era5/download.py
+++ b/src/ecmwf_models/era5/download.py
@@ -25,7 +25,14 @@
 Module to download ERA5 from terminal in netcdf and grib format.
 '''
 
-from ecmwf_models.utils import *
+from ecmwf_models.utils import (load_var_table,
+                                lookup,
+                                save_gribs_from_grib,
+                                save_ncs_from_nc,
+                                mkdate,
+                                str2bool,
+                                )
+import warnings
 import argparse
 import sys
 import os


### PR DESCRIPTION
Fixes https://github.com/TUW-GEO/ecmwf_models/issues/26

If the CDS API does not have any data available we catch this with the error
callback. Only the string `Reason: Request returned no data` is available to
catch this. If the CDS package would ever change their error messages this would
break.

As a return code the python errno.ENODATA is used if no data is present. I've
not been able to find more widely used default error codes so I would argue that
also just using `-10` by convention would be ok instead.

## Other changes

I've also removed the usage of the `*` import in this MR.